### PR TITLE
feat(github-runner-aci): support GitHub App authentication

### DIFF
--- a/github-runner-aci/ConfigureAndRun.ps1
+++ b/github-runner-aci/ConfigureAndRun.ps1
@@ -4,6 +4,9 @@ $apiUrl = $env:GH_RUNNER_API_URL
 $runnerName = $env:GH_RUNNER_NAME
 $runnerGroup = $env:GH_RUNNER_GROUP
 $runnerMode = $env:GH_RUNNER_MODE
+$appId = $env:GH_RUNNER_APP_ID
+$appPrivateKey = $env:GH_RUNNER_APP_PRIVATE_KEY
+$appLogin = $env:GH_RUNNER_APP_LOGIN
 
 $hasRunnerGroup = ($null -ne $runnerGroup -and $runnerGroup -ne "")
 $isEphemeral = $true
@@ -12,38 +15,119 @@ if($null -ne $runnerMode -and $runnerMode -ne "" -and $runnerMode.ToLower() -eq 
     $isEphemeral = $false
 }
 
-# Get the runner registration token from the GitHub API if a PAT is supplied
+# Parse the GitHub URL once - used by both the GitHub App and PAT flows
+$githubUrlSplit = $url.Split("/", [System.StringSplitOptions]::RemoveEmptyEntries)
+if($githubUrlSplit.Length -eq 3) {
+    $githubOrgRepoSegment = $githubUrlSplit[-1]
+    $tokenType = "orgs"
+} else {
+    $githubOrgRepoSegment = $githubUrlSplit[-2] + "/" + $githubUrlSplit[-1]
+    $tokenType = "repos"
+}
+
+if($null -eq $apiUrl -or $apiUrl -eq "") {
+    $domain = $githubUrlSplit[1]
+    if($domain.ToLower() -like "*ghe.com") {
+        $apiUrl = "https://api.$domain"
+    } else {
+        $apiUrl = "https://api.github.com"
+    }
+}
+
+function ConvertTo-Base64Url {
+    param([byte[]]$Bytes)
+    return [Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function New-GitHubAppJwt {
+    param([string]$AppId, [string]$PrivateKeyPem)
+
+    $iat = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - 60
+    $exp = $iat + 600
+
+    $header = '{"alg":"RS256","typ":"JWT"}'
+    $payload = "{`"iat`":$iat,`"exp`":$exp,`"iss`":$AppId}"
+
+    $headerB64 = ConvertTo-Base64Url ([System.Text.Encoding]::UTF8.GetBytes($header))
+    $payloadB64 = ConvertTo-Base64Url ([System.Text.Encoding]::UTF8.GetBytes($payload))
+    $signingInput = "$headerB64.$payloadB64"
+
+    $rsa = [System.Security.Cryptography.RSA]::Create()
+    try {
+        $rsa.ImportFromPem($PrivateKeyPem)
+        $signature = $rsa.SignData(
+            [System.Text.Encoding]::UTF8.GetBytes($signingInput),
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+    } finally {
+        $rsa.Dispose()
+    }
+
+    return "$signingInput." + (ConvertTo-Base64Url $signature)
+}
+
+function Get-GitHubAppInstallationAccessToken {
+    param([string]$AppId, [string]$PrivateKeyPem, [string]$AppLogin, [string]$ApiBaseUrl)
+
+    $jwt = New-GitHubAppJwt -AppId $AppId -PrivateKeyPem $PrivateKeyPem
+    $headers = @{
+        Authorization = "Bearer $jwt"
+        Accept        = "application/vnd.github.v3+json"
+    }
+
+    $installations = Invoke-RestMethod -Uri "$ApiBaseUrl/app/installations" -Headers $headers -Method Get
+    $installation = $installations | Where-Object { $_.account.login -eq $AppLogin -and $_.app_id -eq [int64]$AppId } | Select-Object -First 1
+
+    if($null -eq $installation) {
+        throw "No GitHub App installation found for app id '$AppId' and login '$AppLogin'."
+    }
+
+    return (Invoke-RestMethod -Uri $installation.access_tokens_url -Headers $headers -Method Post).token
+}
+
+# Resolve credentials: GitHub App > PAT > raw runner token
+$hasApp = (-not [string]::IsNullOrEmpty($appId)) -and (-not [string]::IsNullOrEmpty($appPrivateKey))
+$anyAppPart = (-not [string]::IsNullOrEmpty($appId)) -or `
+              (-not [string]::IsNullOrEmpty($appPrivateKey)) -or `
+              (-not [string]::IsNullOrEmpty($appLogin))
+
+$isAppInstallationToken = $false
+if($hasApp) {
+    if(-not [string]::IsNullOrEmpty($token)) {
+        Write-Error "GH_RUNNER_TOKEN cannot be combined with GH_RUNNER_APP_ID/GH_RUNNER_APP_PRIVATE_KEY. These are mutually exclusive."
+        exit 1
+    }
+
+    if([string]::IsNullOrEmpty($appLogin)) {
+        # Default to the org name (or repo owner) parsed from the URL, matching the ACA behaviour
+        $appLogin = $githubUrlSplit[2]
+    }
+
+    # Allow the PEM to be supplied with literal "\n" sequences (common when injecting via env vars)
+    $pem = $appPrivateKey -replace '\\n', "`n"
+
+    Write-Host "Obtaining a GitHub App installation access token for app id $appId and login $appLogin"
+    $token = Get-GitHubAppInstallationAccessToken -AppId $appId -PrivateKeyPem $pem -AppLogin $appLogin -ApiBaseUrl $apiUrl
+    $isAppInstallationToken = $true
+} elseif($anyAppPart) {
+    Write-Error "Partial GitHub App configuration. GH_RUNNER_APP_ID and GH_RUNNER_APP_PRIVATE_KEY must both be supplied."
+    exit 1
+}
+
+# Get the runner registration token from the GitHub API if a PAT or App installation token is in play
 $isPat = $false
-if($token.StartsWith("ghp_") -or $token.StartsWith("github_pat_")) {
+if((-not [string]::IsNullOrEmpty($token)) -and ($token.StartsWith("ghp_") -or $token.StartsWith("github_pat_"))) {
     $isPat = $true
 }
 
-if($isPat) {
-    $githubUrlSplit = $url.Split("/", [System.StringSplitOptions]::RemoveEmptyEntries)
-    $githubOrgRepoSegment = ""
-    $tokenApiUrl = ""
-    $tokenType = ""
-
-    if($githubUrlSplit.Length -eq 3) {
-        $githubOrgRepoSegment = $githubUrlSplit[-1]
-        $tokenType = "orgs"
-    } else {
-        $githubOrgRepoSegment = $githubUrlSplit[-2] + "/" + $githubUrlSplit[-1]
-        $tokenType = "repos"
-    }
-
-    if($null -eq $apiUrl -or $apiUrl -eq "") {
-        $domain = $githubUrlSplit[1]
-        if($domain.ToLower() -like "*ghe.com") {
-            $apiUrl = "https://api.$domain"
-        } else {
-            $apiUrl = "https://api.github.com"
-        }
-    }
-
+if($isPat -or $isAppInstallationToken) {
     $tokenApiUrl = "${apiUrl}/$($tokenType)/$($githubOrgRepoSegment)/actions/runners/registration-token"
 
-    Write-Host "Generating a new runner registration token using the supplied PAT from the url $tokenApiUrl"
+    if($isAppInstallationToken) {
+        Write-Host "Generating a new runner registration token using the GitHub App installation token from the url $tokenApiUrl"
+    } else {
+        Write-Host "Generating a new runner registration token using the supplied PAT from the url $tokenApiUrl"
+    }
 
     $headers = @{}
     $headers.Add("Authorization", "bearer $token")

--- a/github-runner-aci/README.md
+++ b/github-runner-aci/README.md
@@ -4,11 +4,15 @@
 
 ## Environment Variables
 
-`GH_RUNNER_TOKEN`: The token used to authenticate the runner with GitHub. This can be a PAT or a self-hosted runner token. If supplying a self-hosted runner token, be aware that the token will expire after a few hours, so will only work with persistent runners.
+`GH_RUNNER_TOKEN`: The token used to authenticate the runner with GitHub. This can be a PAT or a self-hosted runner token. If supplying a self-hosted runner token, be aware that the token will expire after a few hours, so will only work with persistent runners. Mutually exclusive with `GH_RUNNER_APP_ID`/`GH_RUNNER_APP_PRIVATE_KEY`.
 `GH_RUNNER_URL`: The URL of the GitHub repository or organization (e.g. https://github.com/my-org or https://github.com/my-org/my-repo).
+`GH_RUNNER_API_URL`: Optional. Override for the GitHub REST API base URL. Defaults to `https://api.github.com` for github.com, `https://api.<domain>` for `*.ghe.com`.
 `GH_RUNNER_NAME`: The name of the runner as it appears in GitHub.
 `GH_RUNNER_GROUP`: Optional. If not supplied, the runner will be added to the default group. This requires Enterprise licening.
 `GH_RUNNER_MODE`: Supported values are `ephemeral` and `persistent`. Default is `ephemeral` if the env var is not supplied.
+`GH_RUNNER_APP_ID`: Optional. The GitHub App ID. When supplied together with `GH_RUNNER_APP_PRIVATE_KEY`, the container will mint a JWT, exchange it for an installation access token, and use that to request a runner registration token. Mutually exclusive with `GH_RUNNER_TOKEN`.
+`GH_RUNNER_APP_PRIVATE_KEY`: Optional. The PEM-encoded private key of the GitHub App. Required when `GH_RUNNER_APP_ID` is set. Newlines may be supplied either literally or escaped as `\n`.
+`GH_RUNNER_APP_LOGIN`: Optional. The login (org or repo owner) the GitHub App is installed against. Defaults to the org name (or repo owner) parsed from `GH_RUNNER_URL`.
 
 ## Build it
 


### PR DESCRIPTION
## Summary

Brings GitHub App authentication to the ACI GitHub runner image so it has parity with the ACA image (which already supports it via `app_token.sh` / `entrypoint.sh`).

## Changes

- `github-runner-aci/ConfigureAndRun.ps1`
  - Adds `GH_RUNNER_APP_ID`, `GH_RUNNER_APP_PRIVATE_KEY` and `GH_RUNNER_APP_LOGIN` env vars.
  - Mints an RS256 JWT (using `System.Security.Cryptography.RSA.ImportFromPem` — no extra binaries needed) and exchanges it for an installation access token via `GET /app/installations` and `POST {access_tokens_url}`.
  - Uses the installation token to request a runner registration token via the existing `/orgs/{org}/actions/runners/registration-token` or `/repos/{owner}/{repo}/actions/runners/registration-token` flow.
  - `GH_RUNNER_APP_LOGIN` defaults to the org / repo owner parsed from `GH_RUNNER_URL`, mirroring the ACA behaviour.
  - PEM may be supplied with literal `\n` sequences (auto-converted to real newlines), matching how the ACA script handles `APP_PRIVATE_KEY`.
  - `GH_RUNNER_TOKEN` and the App vars are mutually exclusive; partial App configuration errors out.
  - Hardened `token.StartsWith(...)` against `null` for the case where the user only supplies App credentials.

- `github-runner-aci/README.md`
  - Documents the three new env vars and `GH_RUNNER_API_URL` (already supported, previously undocumented).

## Notes

- No Dockerfile change required — the `mcr.microsoft.com/azure-powershell:ubuntu-24.04` base image already ships a `pwsh` runtime new enough for `RSA.ImportFromPem`.
- Naming follows the existing `GH_RUNNER_*` prefix in the ACI image rather than the bare `APP_*` names used by ACA, to keep the ACI env-var surface internally consistent.
